### PR TITLE
Correct CNAME Deployment

### DIFF
--- a/.github/workflows/build-deploy-site.yml
+++ b/.github/workflows/build-deploy-site.yml
@@ -7,19 +7,18 @@ on:
       - 'docs/**'
     branches:
       - master
-      - enable-auto-deploy-action # TODO remove
       - '!gh-pages'
 
 jobs:
   build-deploy:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
       with:
         submodules: true
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2.3.0
+      uses: peaceiris/actions-hugo@v2
       with:
         hugo-version: '0.59.1'
         extended: true
@@ -28,7 +27,7 @@ jobs:
       run: hugo --minify -v -d docs/
 
     - name: Deploy GitHub Pages
-      uses: peaceiris/actions-gh-pages@v2.5.0
+      uses: peaceiris/actions-gh-pages@v3
       env:
         ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         PUBLISH_BRANCH: gh-pages

--- a/.github/workflows/build-deploy-site.yml
+++ b/.github/workflows/build-deploy-site.yml
@@ -3,7 +3,7 @@ name: Build and Deploy Blog
 on:
   push:
     branches:
-      - master
+      - '*'
       - '!gh-pages'
 
 jobs:

--- a/.github/workflows/build-deploy-site.yml
+++ b/.github/workflows/build-deploy-site.yml
@@ -2,9 +2,6 @@ name: Build and Deploy Blog
 
 on:
   push:
-    # Ignore GH Pages updates (prevent actions recursion)
-    paths-ignore:
-      - 'docs/**'
     branches:
       - master
       - '!gh-pages'
@@ -26,8 +23,10 @@ jobs:
     - name: Build Site
       run: hugo --minify -v -d docs/
 
+    # Only deploy from default branch
     - name: Deploy GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
-      env:
+      if: github.ref == 'refs/heads/master'
+      with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs

--- a/.github/workflows/build-deploy-site.yml
+++ b/.github/workflows/build-deploy-site.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@main
       with:
@@ -29,6 +29,5 @@ jobs:
     - name: Deploy GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
       env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./docs
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs

--- a/.github/workflows/build-deploy-site.yml
+++ b/.github/workflows/build-deploy-site.yml
@@ -30,3 +30,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs
+        cname: lust.dev


### PR DESCRIPTION
The updated deploy plugin was removing the site's CNAME on every deploy. :cry:  Fixed.